### PR TITLE
add program for new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,157 @@
+syntax: glob
+
+### VisualStudio ###
+
+# Tools directory
+.dotnet/
+.packages/
+.tools/
+/[Tt]ools/
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+launchSettings.json
+
+# Build results
+
+artifacts/
+[Dd]ebug/
+[Rr]elease/
+x64/
+x86/ !eng/common/cross/x86/
+[Bb]in/
+[Oo]bj/
+msbuild.log
+msbuild.err
+msbuild.wrn
+*.binlog
+
+# Visual Studio 2015
+.vs/
+
+# Visual Studio 2015 Pre-CTP6
+*.sln.ide
+*.ide/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+#NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# NuGet Packages
+*.nuget.props
+*.nuget.targets
+*.nupkg
+**/packages/*
+
+### Windows ###
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Linux ###
+
+*~
+
+# KDE directory preferences
+.directory
+
+### OSX ###
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# vim temporary files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+# Visual Studio Code
+.vscode/
+.ionide/
+
+# Private test configuration and binaries.
+config.ps1
+**/IISApplications
+
+
+# Node.js modules
+node_modules/
+
+# Python Compile Outputs
+
+*.pyc
+
+# Miscellaneous
+*.log
+*.ncrunchproject
+*.ncrunchsolution
+*.psess
+*.ReSharper
+*.Tests/lib/
+*.userprefs
+*.vsp
+*.xml
+.idea
+_NCrunch_*/
+_ReSharper.*/
+buildlog.txt
+nCrunchTemp*
+TestResults/
+
+.fake
+.ionide
+
+# ApprovalTests
+*.received.txt

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,7 @@
+dotnet publish -c Release ./empty
+
+dotnet publish -c Release ./corefxlab
+
+dotnet publish -c Release ./command-line-api
+
+dotnet publish -c Release ./command-line-api-2

--- a/build.ps1
+++ b/build.ps1
@@ -5,3 +5,5 @@ dotnet publish -c Release ./corefxlab
 dotnet publish -c Release ./command-line-api
 
 dotnet publish -c Release ./command-line-api-2
+
+dotnet publish -c Release ./command-line-api-3

--- a/command-line-api-2/Program.cs
+++ b/command-line-api-2/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public string String { get; set; }
+    public bool Bool { get; set; }
+
+    static void Run(bool b, string s)
+    {
+        Console.WriteLine($"Bool option: {b}");
+        Console.WriteLine($"String option: {s}");
+    }
+
+    private static async Task<int> Main(string[] args)
+    {
+        RootCommand command = new RootCommand();
+        command.AddOption(new Option<bool>(new[] { "--bool", "-b" }, "Bool option"));
+        command.AddOption(new Option<string>(new[] { "--string", "-s" }, "String option"));
+
+        command.Handler = CommandHandler.Create<bool, string>(Run);
+
+        var parser = new Parser(command);
+
+        return await parser.InvokeAsync(args);
+    }
+}

--- a/command-line-api-2/Program.cs
+++ b/command-line-api-2/Program.cs
@@ -10,10 +10,10 @@ public class Program
     public string String { get; set; }
     public bool Bool { get; set; }
 
-    static void Run(bool b, string s)
+    static void Run(Program options)
     {
-        Console.WriteLine($"Bool option: {b}");
-        Console.WriteLine($"String option: {s}");
+        Console.WriteLine($"Bool option: {options.Bool}");
+        Console.WriteLine($"String option: {options.String}");
     }
 
     private static async Task<int> Main(string[] args)
@@ -22,7 +22,7 @@ public class Program
         command.AddOption(new Option<bool>(new[] { "--bool", "-b" }, "Bool option"));
         command.AddOption(new Option<string>(new[] { "--string", "-s" }, "String option"));
 
-        command.Handler = CommandHandler.Create<bool, string>(Run);
+        command.Handler = CommandHandler.Create<Program>(p => Run(p));
 
         var parser = new Parser(command);
 

--- a/command-line-api-2/command-line-api-2.csproj
+++ b/command-line-api-2/command-line-api-2.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="system.commandline" Version="2.0.0-beta1.20315.1" />
+  </ItemGroup>
+
+</Project>

--- a/command-line-api-3/Program.cs
+++ b/command-line-api-3/Program.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public string String { get; set; }
+    public bool Bool { get; set; }
+
+    static void Run(Program options)
+    {
+        Console.WriteLine($"Bool option: {options.Bool}");
+        Console.WriteLine($"String option: {options.String}");
+    }
+
+    private static async Task<int> Main(string[] args)
+    {
+        var boolOption = new Option<bool>(new[] { "--bool", "-b" }, "Bool option");
+        var stringOption = new Option<string>(new[] { "--string", "-s" }, "String option");
+
+        var command = new RootCommand
+        {
+            boolOption,
+            stringOption
+        };
+
+        command.Handler = CommandHandler.Create<ParseResult>(parseResult =>
+        {
+            var model = new Program
+            {
+                Bool = parseResult.ValueForOption<bool>(boolOption.Name),
+                String = parseResult.ValueForOption<string>(stringOption.Name),
+            };
+            Run(model);
+        });
+
+        var parser = new Parser(command);
+
+        return await parser.InvokeAsync(args);
+    }
+}

--- a/command-line-api-3/Program.cs
+++ b/command-line-api-3/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Threading.Tasks;
 
 public class Program
 {
@@ -15,7 +13,7 @@ public class Program
         Console.WriteLine($"String option: {options.String}");
     }
 
-    private static async Task<int> Main(string[] args)
+    private static int Main(string[] args)
     {
         var boolOption = new Option<bool>(new[] { "--bool", "-b" }, "Bool option");
         var stringOption = new Option<string>(new[] { "--string", "-s" }, "String option");
@@ -26,18 +24,18 @@ public class Program
             stringOption
         };
 
-        command.Handler = CommandHandler.Create<ParseResult>(parseResult =>
-        {
-            var model = new Program
-            {
-                Bool = parseResult.ValueForOption<bool>(boolOption.Name),
-                String = parseResult.ValueForOption<string>(stringOption.Name),
-            };
-            Run(model);
-        });
-
         var parser = new Parser(command);
 
-        return await parser.InvokeAsync(args);
+        var parseResult = parser.Parse(args);
+
+        var model = new Program
+        {
+            Bool = parseResult.ValueForOption<bool>(boolOption.Name),
+            String = parseResult.ValueForOption<string>(stringOption.Name),
+        };
+
+        Run(model);
+
+        return 1;
     }
 }

--- a/command-line-api-3/command-line-api-3.csproj
+++ b/command-line-api-3/command-line-api-3.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="system.commandline" Version="2.0.0-beta1.20315.1" />
+  </ItemGroup>
+
+</Project>

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,12 @@
+
+Write-Output "empty:"
+Measure-Command { ./empty/bin/Release/netcoreapp3.1/publish/empty } | foreach { $_.TotalMilliseconds }
+
+Write-Output "corefxlab:"
+Measure-Command { ./corefxlab/bin/Release/netcoreapp3.1/publish/corefxlab -s Hello } | foreach { $_.TotalMilliseconds }
+
+Write-Output "command-line-api:"
+Measure-Command { ./command-line-api/bin/Release/netcoreapp3.1/publish/command-line-api -s Hello } | foreach { $_.TotalMilliseconds }
+
+Write-Output "command-line-api-2:"
+Measure-Command { ./command-line-api-2/bin/Release/netcoreapp3.1/publish/command-line-api-2 -s Hello } | foreach { $_.TotalMilliseconds }

--- a/run.ps1
+++ b/run.ps1
@@ -10,3 +10,6 @@ Measure-Command { ./command-line-api/bin/Release/netcoreapp3.1/publish/command-l
 
 Write-Output "command-line-api-2:"
 Measure-Command { ./command-line-api-2/bin/Release/netcoreapp3.1/publish/command-line-api-2 -s Hello } | foreach { $_.TotalMilliseconds }
+
+Write-Output "command-line-api-3:"
+Measure-Command { ./command-line-api-3/bin/Release/netcoreapp3.1/publish/command-line-api-3 -s Hello } | foreach { $_.TotalMilliseconds }


### PR DESCRIPTION
The adds a new comparison project (command-line-api-2) which incudes a change to the program logic which will exclude the default middleware, and uses an updated version of System.CommandLine with reduced usage of LINQ in the tokenizer. It removes about 25ms on average from the execution time.

Most of the performance gains to be made by optimizing System.CommandLine are in the binding, not the parsing, but this change was very quick to make.

